### PR TITLE
Easier to use

### DIFF
--- a/lib/generators/one_time_password/templates/config/initializers/one_time_password.rb
+++ b/lib/generators/one_time_password/templates/config/initializers/one_time_password.rb
@@ -4,8 +4,10 @@ module OneTimePassword
   # using function_name in OneTimeAuthentication Model.
   # ```
   # # app/models/one_time_authentication.rb
-  # class OneTimeAuthentication < OneTimePassword::Models::OneTimeAuthentication
+  # class OneTimeAuthentication < ActiveRecord::Base
   #   enum function_name: OneTimePassword::FUNCTION_NAMES
+  
+  #   include OneTimePassword::OneTimeAuthenticationModel
   # end
   # ```
   FUNCTION_NAMES = {

--- a/lib/generators/one_time_password/templates/config/initializers/one_time_password.rb
+++ b/lib/generators/one_time_password/templates/config/initializers/one_time_password.rb
@@ -15,7 +15,7 @@ module OneTimePassword
   }
 
   # {
-  #   function_name: OneTimeAuthentication's function_name index.(Integer)
+  #   function_name: OneTimeAuthentication's function_name index.(Symbol)
   #   version: Version each function_name.(String)
   #   expires_in: (ActiveSupport::Duration)
   #   max_authenticate_password_count: Number of times you can enter your password.(Integer)
@@ -23,7 +23,7 @@ module OneTimePassword
   # }
   CONTEXTS = [
     {
-      function_name: FUNCTION_NAMES[:sign_up],
+      function_name: :sign_up,
       version: 0,
       expires_in: 30.minutes,
       max_authenticate_password_count: 5,
@@ -32,7 +32,7 @@ module OneTimePassword
       password_failed_period: 1.hour
     },
     {
-      function_name: FUNCTION_NAMES[:sign_in],
+      function_name: :sign_in,
       version: 0,
       expires_in: 30.minutes,
       max_authenticate_password_count: 5,
@@ -41,7 +41,7 @@ module OneTimePassword
       password_failed_period: 1.hour
     },
     # {
-    #   function_name: FUNCTION_NAMES[:change_email],
+    #   function_name: :change_email,
     #   version: 0,
     #   expires_in: 30.minutes,
     #   max_authenticate_password_count: 5,

--- a/lib/one_time_password.rb
+++ b/lib/one_time_password.rb
@@ -1,7 +1,3 @@
 require "one_time_password/version"
 require "one_time_password/railtie"
 require "one_time_password/one_time_authentication_model"
-
-module OneTimePassword
-  # Your code goes here...
-end

--- a/lib/one_time_password/one_time_authentication_model.rb
+++ b/lib/one_time_password/one_time_authentication_model.rb
@@ -42,7 +42,9 @@ module OneTimePassword
         context
       end
 
-      def create_one_time_authentication(context, user_key)
+      def create_one_time_authentication(context, user_key, user_key_downcase: true)
+        user_key = user_key.downcase if user_key_downcase
+
         recent_failed_authenticate_password_count =
           OneTimeAuthentication
             .recent_failed_authenticate_password_count(
@@ -68,7 +70,9 @@ module OneTimePassword
         one_time_authentication
       end
 
-      def find_one_time_authentication(context, user_key)
+      def find_one_time_authentication(context, user_key, user_key_downcase: true)
+        user_key = user_key.downcase if user_key_downcase
+
         OneTimeAuthentication
           .where(function_name: context[:function_name])
           .where(version: context[:version])

--- a/lib/one_time_password/one_time_authentication_model.rb
+++ b/lib/one_time_password/one_time_authentication_model.rb
@@ -17,7 +17,7 @@ module OneTimePassword
     end
 
     module ClassMethods
-      def find_context(function_name, version)
+      def find_context(function_name, version: 0)
         context = OneTimePassword::CONTEXTS
           .select{ |context|
             context[:function_name] == function_name &&

--- a/spec/dummy/app/controllers/test_users_controller.rb
+++ b/spec/dummy/app/controllers/test_users_controller.rb
@@ -60,7 +60,7 @@ class TestUsersController < ApplicationController
 
     # error
     return render :json => {}, status: 401
-  rescue => e
+  rescue
     # error
     return render :json => {}, status: 401
   end

--- a/spec/dummy/app/controllers/test_users_controller.rb
+++ b/spec/dummy/app/controllers/test_users_controller.rb
@@ -7,8 +7,7 @@ class TestUsersController < ApplicationController
     end
 
     context = OneTimeAuthentication.find_context(
-      OneTimePassword::FUNCTION_NAMES[:sign_up],
-      0
+      OneTimePassword::FUNCTION_NAMES[:sign_up]
     )
     one_time_authentication = OneTimeAuthentication.create_one_time_authentication(
       context,
@@ -37,8 +36,7 @@ class TestUsersController < ApplicationController
     end
 
     context = OneTimeAuthentication.find_context(
-      OneTimePassword::FUNCTION_NAMES[:sign_up],
-      0
+      OneTimePassword::FUNCTION_NAMES[:sign_up]
     )
     one_time_authentication = OneTimeAuthentication.find_one_time_authentication(
       context,

--- a/spec/dummy/app/controllers/test_users_controller.rb
+++ b/spec/dummy/app/controllers/test_users_controller.rb
@@ -9,7 +9,7 @@ class TestUsersController < ApplicationController
     context = OneTimeAuthentication.find_context(:sign_up)
     one_time_authentication = OneTimeAuthentication.create_one_time_authentication(
       context,
-      params[:email].downcase
+      params[:email]
     )
     if one_time_authentication.present?
       # success
@@ -36,7 +36,7 @@ class TestUsersController < ApplicationController
     context = OneTimeAuthentication.find_context(:sign_up)
     one_time_authentication = OneTimeAuthentication.find_one_time_authentication(
       context,
-      params[:email].downcase
+      params[:email]
     )
     new_client_token = one_time_authentication.authenticate_one_time_client_token!(params[:client_token])
     if new_client_token

--- a/spec/dummy/app/controllers/test_users_controller.rb
+++ b/spec/dummy/app/controllers/test_users_controller.rb
@@ -6,9 +6,7 @@ class TestUsersController < ApplicationController
       return render :json => {}, status: 400
     end
 
-    context = OneTimeAuthentication.find_context(
-      OneTimePassword::FUNCTION_NAMES[:sign_up]
-    )
+    context = OneTimeAuthentication.find_context(:sign_up)
     one_time_authentication = OneTimeAuthentication.create_one_time_authentication(
       context,
       params[:email].downcase
@@ -35,9 +33,7 @@ class TestUsersController < ApplicationController
       return render :json => {}, status: 400
     end
 
-    context = OneTimeAuthentication.find_context(
-      OneTimePassword::FUNCTION_NAMES[:sign_up]
-    )
+    context = OneTimeAuthentication.find_context(:sign_up)
     one_time_authentication = OneTimeAuthentication.find_one_time_authentication(
       context,
       params[:email].downcase

--- a/spec/models/one_time_authentication_spec.rb
+++ b/spec/models/one_time_authentication_spec.rb
@@ -204,14 +204,14 @@ describe 'OneTimeAuthentication' do
 
       context 'Exist version' do
         it 'Return selected context' do
-          expect(OneTimeAuthentication.find_context(function_name, 0))
+          expect(OneTimeAuthentication.find_context(function_name))
             .to eq(sign_up_context)
         end
       end
 
       context 'Not exist version' do
         it 'Raise error' do
-          expect{ OneTimeAuthentication.find_context(function_name, 1) }
+          expect{ OneTimeAuthentication.find_context(function_name, version: 1) }
             .to raise_error(ArgumentError, 'Not found context.')
         end
       end
@@ -222,14 +222,14 @@ describe 'OneTimeAuthentication' do
 
       context 'exist version' do
         it 'Raise error' do
-          expect{ OneTimeAuthentication.find_context(function_name, 0) }
+          expect{ OneTimeAuthentication.find_context(function_name) }
             .to raise_error(ArgumentError, 'Not found context.')
         end
       end
 
       context 'Not exist version' do
         it 'Raise error' do
-          expect{ OneTimeAuthentication.find_context(function_name, 1) }
+          expect{ OneTimeAuthentication.find_context(function_name, version: 1) }
            .to raise_error(ArgumentError, 'Not found context.')
         end
       end

--- a/spec/models/one_time_authentication_spec.rb
+++ b/spec/models/one_time_authentication_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe 'OneTimeAuthentication' do
   let(:sign_up_context) do
     {
-      function_name: OneTimePassword::FUNCTION_NAMES[:sign_up],
+      function_name: :sign_up,
       version: 0,
       expires_in: 30.minutes,
       max_authenticate_password_count: 5,
@@ -14,7 +14,7 @@ describe 'OneTimeAuthentication' do
   end
   let(:sign_in_context) do
     {
-      function_name: OneTimePassword::FUNCTION_NAMES[:sign_in],
+      function_name: :sign_in,
       version: 0,
       expires_in: 30.minutes,
       max_authenticate_password_count: 5,
@@ -200,7 +200,7 @@ describe 'OneTimeAuthentication' do
 
   describe '#self.find_context' do
     context 'Exist function_name' do
-      let(:function_name) { OneTimePassword::FUNCTION_NAMES[:sign_up] }
+      let(:function_name) { :sign_up }
 
       context 'Exist version' do
         it 'Return selected context' do
@@ -218,7 +218,7 @@ describe 'OneTimeAuthentication' do
     end
 
     context 'Not exist function_name' do
-      let(:function_name) { OneTimePassword::FUNCTION_NAMES[:change_email] }
+      let(:function_name) { :change_email }
 
       context 'exist version' do
         it 'Raise error' do
@@ -238,7 +238,7 @@ describe 'OneTimeAuthentication' do
 
   describe '#self.create_one_time_authentication' do
     let!(:now) { Time.parse('2022-3-26 12:00') }
-    let(:function_name) { OneTimePassword::FUNCTION_NAMES[:sign_in] }
+    let(:function_name) { :sign_in }
 
     context 'recent_failed_authenticate_password_count <= 10 from 1 hour ago' do
       let!(:failed_one_time_authentications) {
@@ -376,7 +376,7 @@ describe 'OneTimeAuthentication' do
   end
 
   describe '#self.find_one_time_authentication' do
-    let(:function_name) { OneTimePassword::FUNCTION_NAMES[:sign_in] }
+    let(:function_name) { :sign_in }
 
     context 'There is a match function_name, version and user_key in the table' do
       let!(:one_time_authentications) do
@@ -461,7 +461,7 @@ describe 'OneTimeAuthentication' do
   end
 
   describe '#expired?' do
-    let(:function_name) { OneTimePassword::FUNCTION_NAMES[:sign_in] }
+    let(:function_name) { :sign_in }
 
     let(:beginning_of_validity_period) { Time.new(2022, 1, 1, 12) }
     let!(:one_time_authentication) do
@@ -507,7 +507,7 @@ describe 'OneTimeAuthentication' do
   end
 
   describe '#under_valid_failed_count?' do
-    let(:function_name) { OneTimePassword::FUNCTION_NAMES[:sign_in] }
+    let(:function_name) { :sign_in }
     let!(:one_time_authentication) do
       FactoryBot.create(
         :one_time_authentication,
@@ -549,7 +549,7 @@ describe 'OneTimeAuthentication' do
   end
 
   describe '#authenticate_client_token' do
-    let(:function_name) { OneTimePassword::FUNCTION_NAMES[:sign_in] }
+    let(:function_name) { :sign_in }
     let!(:one_time_authentication) do
       # First client_token
       allow(SecureRandom).to receive(:urlsafe_base64).and_return('XXXXXXXXXXXXXXX')
@@ -618,7 +618,7 @@ describe 'OneTimeAuthentication' do
   end
 
   describe '#authenticate_password' do
-    let(:function_name) { OneTimePassword::FUNCTION_NAMES[:sign_in] }
+    let(:function_name) { :sign_in }
     let(:failed_count) { 0 }
     let(:beginning_of_validity_period) { Time.new(2022, 1, 1, 12) }
     let!(:one_time_authentication) do

--- a/spec/models/one_time_authentication_spec.rb
+++ b/spec/models/one_time_authentication_spec.rb
@@ -373,6 +373,33 @@ describe 'OneTimeAuthentication' do
         end
       end
     end
+
+    describe 'user_key_downcase' do
+      let(:uppercase_user_key) { 'USER@example.com' }
+
+      context 'user_key_downcase is true(default)' do
+        it 'user_key is downcase string' do
+          expect(
+            OneTimeAuthentication.create_one_time_authentication(
+              sign_in_context,
+              uppercase_user_key
+            ).user_key
+          ).to eq('user@example.com')
+        end
+      end
+
+      context 'user_key_downcase is false' do
+        it 'user_key is include uppercase string' do
+          expect(
+            OneTimeAuthentication.create_one_time_authentication(
+              sign_in_context,
+              uppercase_user_key,
+              user_key_downcase: false
+            ).user_key
+          ).to eq('USER@example.com')
+        end
+      end
+    end
   end
 
   describe '#self.find_one_time_authentication' do
@@ -456,6 +483,47 @@ describe 'OneTimeAuthentication' do
         expect(
           OneTimeAuthentication.find_one_time_authentication(sign_in_context, user_key)
         ).to eq(nil)
+      end
+    end
+
+    describe 'user_key_downcase' do
+      let(:uppercase_user_key) { 'USER@example.com' }
+      let!(:lowercase_user_key_one_time_authentication) do
+        FactoryBot.create(
+          :one_time_authentication,
+          function_name: :sign_in,
+          user_key: user_key
+        )
+      end
+      let!(:uppercase_user_key_one_time_authentication) do
+        FactoryBot.create(
+          :one_time_authentication,
+          function_name: :sign_in,
+          user_key: uppercase_user_key
+        )
+      end
+
+      context 'user_key_downcase is true(default)' do
+        it 'user_key is downcase string' do
+          expect(
+            OneTimeAuthentication.find_one_time_authentication(
+              sign_in_context,
+              uppercase_user_key
+            ).user_key
+          ).to eq('user@example.com')
+        end
+      end
+
+      context 'user_key_downcase is false' do
+        it 'user_key is include uppercase string' do
+          expect(
+            OneTimeAuthentication.find_one_time_authentication(
+              sign_in_context,
+              uppercase_user_key,
+              user_key_downcase: false
+            ).user_key
+          ).to eq('USER@example.com')
+        end
       end
     end
   end


### PR DESCRIPTION
```ruby
- function_name: FUNCTION_NAMES[:sign_up],
+ function_name: :sign_up,

- context = OneTimeAuthentication.find_context(
-   OneTimePassword::FUNCTION_NAMES[:sign_up],
-   0
- )
+ context = OneTimeAuthentication.find_context(:sign_up)
```

and we no longer have to downcase user_key.